### PR TITLE
#160108123 add a feature to identify the current tab on the profile page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/.nyc_output/

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,1 +1,0 @@
-/node_modules/

--- a/ui/about.html
+++ b/ui/about.html
@@ -184,6 +184,7 @@
             </a>
         </center>
     </footer>
+    <br id="post-button"/>
     <script type="text/javascript" src="script.js"></script>
 </body>
 

--- a/ui/profile.html
+++ b/ui/profile.html
@@ -113,8 +113,8 @@
                     <h2>Number of answers given :</h2> <span><h2>5</h2></span> <br>
                 </div>
                 <header class="tab">  
-                    <a  href="./list-of-question.html" target="list-frame">LIST OF RECENT QUESTIONS</a> |
-                    <a href="./question-most-answers.html" target="list-frame">QUESTIONS WITH MOST ANSWER</a>
+                    <a id="lirQuestions" href="./list-of-question.html" target="list-frame">LIST OF RECENT QUESTIONS</a> |
+                    <a id="limQuestions" href="./question-most-answers.html" target="list-frame">QUESTIONS WITH MOST ANSWER</a>
                 <hr>
                 </header>
 
@@ -184,7 +184,7 @@
             </a>
         </center>
     </footer>
-    <script type="text/javascript" src="script.js"></script>
+    <script type="text/javascript" src="profileScript.js"></script>
 </body>
 
 </html>

--- a/ui/profileScript.js
+++ b/ui/profileScript.js
@@ -1,0 +1,34 @@
+/*---------------Profile Page--------------*/
+const lim = document.getElementById("limQuestions");
+const lir = document.getElementById("lirQuestions");
+
+const toggle = () => {
+    lir.style.color = "#0044ff";
+    lir.style.fontWeight = "bolder";
+    lim.style.color = "black";
+}
+toggle();
+
+lir.onclick = () => {
+    lir.style.color = "#0044ff";
+    lir.style.fontWeight = "bolder";
+    lim.style.color = "black";
+    lim.style.fontWeight = "normal";
+}
+
+lim.onclick = () => {
+    lir.style.color = "black";
+    lim.style.color = "#0044ff";
+    lim.style.fontWeight = "bolder";
+    lir.style.fontWeight = "normal";
+}
+
+//-------------LOGSOUT USER--------------------
+let logout = document.getElementById("logout");
+
+logout.onclick = () => {
+    let check = confirm("ARE YOU SURE?");
+    if (check) {
+        window.location.assign("./index.html");
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Have a **list of recent questions** and **questions with most answers** tab on the profile page active when toggled

#### Description of Task to be completed?
Having list of recent question and questions with most answers toggle when active and toggled down when inactive

#### How should this be manually tested?
* Visit the gh-pages template from this url https://shaolinmkz.github.io/StackOverflow-lite/ui/
* Navigate to the profile page.
* Test by clicking on each tab.

#### Any background context you want to provide?
Bold blue signifies current tab.

#### What are the relevant pivotal tracker stories?
#160108123
#### Screenshots 
![profile](https://user-images.githubusercontent.com/38951888/44751394-f8184780-ab0f-11e8-858e-fb2e4e140874.gif)
